### PR TITLE
feat: packageJson의 hompage value값 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://seunggyu-jung.github.io/interview_page_test/",
+  "homepage": "https://seunggyu-jung.github.io/",
   "name": "interview_summary",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
# 1. packageJson의 hompage value값을 변경 했습니다.
- 기존의 홈페이지 value값이 "homepage": "https://seunggyu-jung.github.io/interview_test"였을때는 렌더링이 안되는 오류가 있었습니다.
- npm start로 할 경우 "homepage": "localhost3000/interview_test"은 안되지만, "homepage": "https://seunggyu-jung.github.io"로 바꾸니 자연스럽게 실행이 되어서 다음과 같이 수정하여 올렸습니다.
- 다만, 제 개인 깃헙 페이지 중 URL 주소가 "https://seunggyu-jung.github.io"인 것이 있어 실행이 될지는 풀리를 하고나서 실행해보야할 듯 합니다.